### PR TITLE
Follow the OS theme until the user toggles

### DIFF
--- a/app/components/ModeToggle.tsx
+++ b/app/components/ModeToggle.tsx
@@ -11,7 +11,14 @@ export function ModeToggle() {
         const root = document.documentElement;
         const next = root.classList.contains("dark") ? "light" : "dark";
         root.classList.toggle("dark", next === "dark");
-        localStorage.setItem("theme", next);
+        const system = matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+        if (next === system) {
+          localStorage.removeItem("theme");
+        } else {
+          localStorage.setItem("theme", next);
+        }
       }}
     >
       <IconSun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,7 +17,22 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
-const themeScript = `(()=>{var t=localStorage.getItem("theme");if(t==="dark"||(t!=="light"&&matchMedia("(prefers-color-scheme: dark)").matches))document.documentElement.classList.add("dark")})();`;
+const themeScript = `(() => {
+  const root = document.documentElement;
+  const media = matchMedia("(prefers-color-scheme: dark)");
+  const apply = () => {
+    const stored = localStorage.getItem("theme");
+    root.classList.toggle(
+      "dark",
+      stored === "dark" || (stored !== "light" && media.matches),
+    );
+  };
+  apply();
+  media.addEventListener("change", () => {
+    const stored = localStorage.getItem("theme");
+    if (stored !== "light" && stored !== "dark") apply();
+  });
+})();`;
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -25,8 +25,13 @@ function isHomepageGet(request: Request): boolean {
   return new URL(request.url).pathname === "/";
 }
 
+// Bump when homepage HTML or the theme boot script changes.
+const HOMEPAGE_CACHE_VERSION = "2";
+
 function homepageCacheKey(request: Request): Request {
-  return new Request(new URL("/", request.url).href, { method: "GET" });
+  const url = new URL("/", request.url);
+  url.searchParams.set("v", HOMEPAGE_CACHE_VERSION);
+  return new Request(url.href, { method: "GET" });
 }
 
 function edgeCache(): Cache {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The live site stayed on whatever `localStorage.theme` last wrote, and never moved with the OS after that first click. Homepage HTML can also sit in `caches.default` across deploys, so an old boot script can keep serving.

**Default is the system theme.** The inline boot script in `app/root.tsx` applies `class="dark"` on `<html>` before paint when `theme` is not `light` or `dark`. It also listens to `prefers-color-scheme` changes and updates the class until the user sets an override.

**Toggle is an override, not a lock.** `ModeToggle` still writes `light` or `dark` when the click disagrees with the OS. If the click lands on the current system value, it clears `localStorage` so the page tracks the OS again. Same sun/moon button. No settings menu, cookies, or remix-themes.

**Cache key bump.** `workers/app.ts` now keys the homepage cache as `/?v=2`. Old cached HTML cannot be reused after this ships.

Not deploying. Someone still has to merge and deploy for the live site to pick this up.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a7e4dd0-b820-4264-99e1-6fe8bfcdd538?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a7e4dd0-b820-4264-99e1-6fe8bfcdd538&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

