### PR TITLE
Polish WAYF: create POST, About overlay, a11y

### DIFF
--- a/app/components/AboutPopover.tsx
+++ b/app/components/AboutPopover.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/ui/button";
+import { useEffect, useId, useRef, useState } from "react";
+
+export function AboutPopover() {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    const onPointer = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("pointerdown", onPointer);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("pointerdown", onPointer);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <Button
+        variant="link"
+        type="button"
+        aria-expanded={open}
+        aria-controls={titleId}
+        onClick={() => setOpen((current) => !current)}
+      >
+        About
+      </Button>
+      {open ? (
+        <div
+          id={titleId}
+          role="dialog"
+          aria-label="WAYF: When are you free?"
+          className="absolute left-1/2 z-50 w-72 -translate-x-1/2 rounded-md border bg-popover p-4 text-left text-sm text-popover-foreground shadow-md"
+        >
+          <p className="pb-1 font-semibold">WAYF: When are you free?</p>
+          <p>
+            Scheduling applications have become increasingly complicated. They
+            are littered with unnecessary features and demand user accounts.
+            WAYF focuses on a user-friendly experience to find the perfect
+            meeting times for everyone involved. Say goodbye to unnecessary
+            complexities and hello to efficient, stress-free scheduling.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/FormError.tsx
+++ b/app/components/FormError.tsx
@@ -1,0 +1,15 @@
+export function FormError({
+  id,
+  message,
+}: {
+  id?: string;
+  message?: string;
+}) {
+  if (!message) return null;
+
+  return (
+    <p id={id} role="alert" className="w-full text-sm text-destructive">
+      {message}
+    </p>
+  );
+}

--- a/app/components/ModeToggle.tsx
+++ b/app/components/ModeToggle.tsx
@@ -7,6 +7,7 @@ export function ModeToggle() {
       variant="ghost"
       size="icon"
       type="button"
+      aria-label="Toggle theme"
       onClick={() => {
         const root = document.documentElement;
         const next = root.classList.contains("dark") ? "light" : "dark";
@@ -21,8 +22,8 @@ export function ModeToggle() {
         }
       }}
     >
-      <IconSun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <IconMoon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <IconSun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <IconMoon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   );

--- a/app/components/ShareButton.tsx
+++ b/app/components/ShareButton.tsx
@@ -36,7 +36,7 @@ const ShareButton = ({ params: { meet } }: { params: { meet: Meet } }) => {
 
   return (
     <>
-      <Button onClick={share} variant={"outline"}>
+      <Button onClick={share} type="button" variant="outline">
         <span className="pr-1">Share</span>
         <IconShare />
       </Button>

--- a/app/components/icons.tsx
+++ b/app/components/icons.tsx
@@ -113,7 +113,7 @@ export function IconCheck({ className }: { className?: string }) {
       height="20"
       viewBox="0 0 24 24"
       fill="none"
-      stroke="#16a34a"
+      stroke="currentColor"
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -20,10 +20,10 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
+        default: "h-11 min-h-11 px-4 py-2",
         sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        lg: "h-11 min-h-11 rounded-md px-8",
+        icon: "relative h-11 w-11 min-h-11 min-w-11",
       },
     },
     defaultVariants: {

--- a/app/components/ui/calendar.tsx
+++ b/app/components/ui/calendar.tsx
@@ -25,19 +25,19 @@ function Calendar({
         nav: "space-x-1 flex items-center",
         nav_button: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+          "h-11 w-11 bg-transparent p-0 opacity-50 hover:opacity-100",
         ),
         nav_button_previous: "absolute left-1",
         nav_button_next: "absolute right-1",
         table: "w-full border-collapse space-y-1",
         head_row: "flex",
         head_cell:
-          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+          "text-muted-foreground rounded-md w-11 font-normal text-[0.8rem]",
         row: "flex w-full mt-2",
-        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        cell: "h-11 w-11 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
+          "h-11 w-11 p-0 font-normal aria-selected:opacity-100",
         ),
         day_range_end: "day-range-end",
         day_selected:

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-11 min-h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base caret-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/app/lib/create-meetup.server.ts
+++ b/app/lib/create-meetup.server.ts
@@ -1,22 +1,38 @@
 import { create } from "@/api/services/meet";
 import { getDatabaseUrl } from "@/env";
+import type { FormErrorKey } from "@/lib/form-errors";
 import type { AppLoadContext } from "react-router";
 import { redirect } from "react-router";
 
-export async function createMeetupResponse(
+export type CreateMeetupResult =
+  | Response
+  | { error: Extract<FormErrorKey, "name" | "create"> };
+
+export async function createMeetupAction(
   request: Request,
   context: AppLoadContext,
-): Promise<Response> {
+): Promise<CreateMeetupResult> {
   const formData = await request.formData();
   const name = String(formData.get("name") ?? "").trim();
   if (!name) {
-    return redirect("/?error=name", 303);
+    return { error: "name" };
   }
 
   try {
     const id = await create(getDatabaseUrl(context), name);
     return redirect(`/m/${id}`, 303);
   } catch {
-    return redirect("/?error=create", 303);
+    return { error: "create" };
   }
+}
+
+export async function createMeetupResponse(
+  request: Request,
+  context: AppLoadContext,
+): Promise<Response> {
+  const result = await createMeetupAction(request, context);
+  if (result instanceof Response) {
+    return result;
+  }
+  return redirect(`/?error=${result.error}`, 303);
 }

--- a/app/lib/create-meetup.server.ts
+++ b/app/lib/create-meetup.server.ts
@@ -1,0 +1,22 @@
+import { create } from "@/api/services/meet";
+import { getDatabaseUrl } from "@/env";
+import type { AppLoadContext } from "react-router";
+import { redirect } from "react-router";
+
+export async function createMeetupResponse(
+  request: Request,
+  context: AppLoadContext,
+): Promise<Response> {
+  const formData = await request.formData();
+  const name = String(formData.get("name") ?? "").trim();
+  if (!name) {
+    return redirect("/?error=name", 303);
+  }
+
+  try {
+    const id = await create(getDatabaseUrl(context), name);
+    return redirect(`/m/${id}`, 303);
+  } catch {
+    return redirect("/?error=create", 303);
+  }
+}

--- a/app/lib/dates.ts
+++ b/app/lib/dates.ts
@@ -40,6 +40,11 @@ export function formatDayHeading(day: string): string {
   return `${WEEKDAYS[date.getDay()]}, ${MONTHS[date.getMonth()]} ${date.getDate()}`;
 }
 
+export function startOfToday(): Date {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
 export function isValidDay(day: string): boolean {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) {
     return false;

--- a/app/lib/form-errors.ts
+++ b/app/lib/form-errors.ts
@@ -1,0 +1,14 @@
+export const formErrors = {
+  name: "Enter a name.",
+  create: "Could not create. Try again.",
+  save: "Could not save. Try again.",
+} as const;
+
+export type FormErrorKey = keyof typeof formErrors;
+
+export function formErrorMessage(key: string | null): string | undefined {
+  if (key && key in formErrors) {
+    return formErrors[key as FormErrorKey];
+  }
+  return undefined;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -87,7 +87,11 @@ export default function App() {
 
 export function ErrorBoundary({ error }: { error: unknown }) {
   const notFound = isRouteErrorResponse(error) && error.status === 404;
-  const message = notFound ? "Meetup not found" : "Something went wrong";
+  const message = notFound
+    ? typeof error.data === "string" && error.data
+      ? error.data
+      : "Not found"
+    : "Something went wrong";
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-sm flex-col items-center justify-center px-4">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,8 +9,8 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  type LinksFunction,
 } from "react-router";
-import type { LinksFunction } from "react-router";
 import stylesheet from "./tailwind.css?url";
 
 export const links: LinksFunction = () => [
@@ -57,38 +57,37 @@ export default function App() {
   return (
     <main className="mx-auto flex min-h-dvh max-w-sm flex-col items-center justify-between px-4">
       <Outlet />
-      <div className="flex w-full flex-col items-center justify-between gap-1 pt-8">
-        <div className="h-[1px] w-full shrink-0 bg-border" />
-        <div className="flex w-full flex-row items-center justify-between pb-4">
-          <Link to="/">
-            <span className="text-m scroll-m-20 font-semibold tracking-tight">
-              WAYF
-            </span>
+      <footer className="flex w-full flex-col pt-10">
+        <div className="h-px w-full bg-border" />
+        <div className="flex w-full items-center justify-between py-3">
+          <Link
+            to="/"
+            className="inline-flex h-11 items-center text-base font-semibold tracking-tight"
+          >
+            WAYF
           </Link>
-          <div className="flex flex-row items-center">
+          <div className="flex items-center">
             <Button variant="ghost" size="icon" asChild>
               <a
                 href="https://github.com/runandrew/remix-wayf"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="WAYF on GitHub"
               >
-                <IconGithub className="h-[1.2rem] w-[1.2rem]" />
+                <IconGithub className="h-5 w-5" />
               </a>
             </Button>
             <ModeToggle />
           </div>
         </div>
-      </div>
+      </footer>
     </main>
   );
 }
 
 export function ErrorBoundary({ error }: { error: unknown }) {
-  const message = isRouteErrorResponse(error)
-    ? error.status === 404
-      ? "Not found"
-      : "Something went wrong"
-    : "Something went wrong";
+  const notFound = isRouteErrorResponse(error) && error.status === 404;
+  const message = notFound ? "Meetup not found" : "Something went wrong";
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-sm flex-col items-center justify-center px-4">

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -2,6 +2,7 @@ import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
 export default [
   index("routes/home.tsx"),
+  route("create", "routes/create.ts"),
   route("m/:uuid", "routes/m.$uuid.tsx"),
   route("m/:uuid/avails", "routes/m.$uuid.avails.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/create.ts
+++ b/app/routes/create.ts
@@ -1,0 +1,9 @@
+import { createMeetupResponse } from "@/lib/create-meetup.server";
+import type { ActionFunctionArgs } from "react-router";
+import { redirect } from "react-router";
+
+export const loader = () => redirect("/", 302);
+
+export const action = async ({ request, context }: ActionFunctionArgs) => {
+  return createMeetupResponse(request, context);
+};

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,9 +1,10 @@
-import { create } from "@/api/services/meet";
+import { AboutPopover } from "@/components/AboutPopover";
+import { FormError } from "@/components/FormError";
 import { SubmitButton } from "@/components/SubmitButton";
 import { Input } from "@/components/ui/input";
-import { getDatabaseUrl } from "@/env";
-import type { ActionFunctionArgs, MetaFunction } from "react-router";
-import { Form, redirect, useNavigation } from "react-router";
+import { formErrorMessage } from "@/lib/form-errors";
+import type { MetaFunction } from "react-router";
+import { Form, useNavigation, useSearchParams } from "react-router";
 
 export const meta: MetaFunction = () => {
   return [
@@ -19,59 +20,45 @@ export function headers() {
   };
 }
 
-export const action = async ({ request, context }: ActionFunctionArgs) => {
-  const formData = await request.formData();
-  const name = String(formData.get("name") ?? "").trim();
-  if (!name) {
-    throw new Response("Name is required", { status: 400 });
-  }
-  const id = await create(getDatabaseUrl(context), name);
-  return redirect(`/m/${id}`);
-};
-
 export default function Index() {
   const navigation = useNavigation();
+  const [searchParams] = useSearchParams();
+  const error = formErrorMessage(searchParams.get("error"));
+  const submitting = navigation.state === "submitting";
 
   return (
-    <div className="flex w-full flex-col items-center gap-4 pt-20">
-      <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-3xl">
-        WAYF
-      </h1>
-      <h4 className="scroll-m-20 pb-4 text-xl font-semibold tracking-tight">
-        Scheduling meetups <i>simplified</i>
-      </h4>
-      <Form method="post">
-        <div className="flex flex-row gap-4">
+    <div className="flex w-full flex-col items-center gap-6 pt-16">
+      <div className="flex w-full flex-col items-center gap-2">
+        <h1 className="text-4xl font-extrabold tracking-tight">WAYF</h1>
+        <p className="text-xl font-semibold tracking-tight">
+          Scheduling meetups <i>simplified</i>
+        </p>
+      </div>
+      <Form method="post" action="/create" className="flex w-full flex-col gap-2">
+        <div className="flex flex-row items-center gap-3">
+          <label htmlFor="meetup-name" className="sr-only">
+            Meetup name
+          </label>
           <Input
+            id="meetup-name"
             name="name"
-            type="name"
+            type="text"
             placeholder="Name, e.g. Book Club 📚"
             autoComplete="off"
             autoCapitalize="words"
             required
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? "create-error" : undefined}
           />
           <SubmitButton
-            submitting={navigation.state === "submitting"}
+            submitting={submitting}
             text="Create"
             disabled={navigation.state === "loading"}
           />
         </div>
+        <FormError id="create-error" message={error} />
       </Form>
-      <details className="w-full max-w-sm text-center">
-        <summary className="cursor-pointer text-sm font-medium underline-offset-4 hover:underline">
-          About
-        </summary>
-        <div className="pt-2 text-left text-sm">
-          <h5 className="font-semibold pb-1">WAYF: When are you free?</h5>
-          <p>
-            Scheduling applications have become increasingly complicated. They
-            are littered with unnecessary features and demand user accounts.
-            WAYF focuses on a user-friendly experience to find the perfect
-            meeting times for everyone involved. Say goodbye to unnecessary
-            complexities and hello to efficient, stress-free scheduling.
-          </p>
-        </div>
-      </details>
+      <AboutPopover />
     </div>
   );
 }

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -2,9 +2,15 @@ import { AboutPopover } from "@/components/AboutPopover";
 import { FormError } from "@/components/FormError";
 import { SubmitButton } from "@/components/SubmitButton";
 import { Input } from "@/components/ui/input";
+import { createMeetupAction } from "@/lib/create-meetup.server";
 import { formErrorMessage } from "@/lib/form-errors";
-import type { MetaFunction } from "react-router";
-import { Form, useNavigation, useSearchParams } from "react-router";
+import type { ActionFunctionArgs, MetaFunction } from "react-router";
+import {
+  Form,
+  useActionData,
+  useNavigation,
+  useSearchParams,
+} from "react-router";
 
 export const meta: MetaFunction = () => {
   return [
@@ -13,17 +19,18 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-export function headers() {
-  return {
-    "Cache-Control":
-      "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
-  };
-}
+export const action = async ({ request, context }: ActionFunctionArgs) => {
+  return createMeetupAction(request, context);
+};
 
 export default function Index() {
   const navigation = useNavigation();
   const [searchParams] = useSearchParams();
-  const error = formErrorMessage(searchParams.get("error"));
+  const actionData = useActionData<typeof action>();
+  const error = formErrorMessage(
+    (actionData && "error" in actionData ? actionData.error : null) ??
+      searchParams.get("error"),
+  );
   const submitting = navigation.state === "submitting";
 
   return (
@@ -34,7 +41,7 @@ export default function Index() {
           Scheduling meetups <i>simplified</i>
         </p>
       </div>
-      <Form method="post" action="/create" className="flex w-full flex-col gap-2">
+      <Form method="post" action="/?index" className="flex w-full flex-col gap-2">
         <div className="flex flex-row items-center gap-3">
           <label htmlFor="meetup-name" className="sr-only">
             Meetup name

--- a/app/routes/m.$uuid.avails.tsx
+++ b/app/routes/m.$uuid.avails.tsx
@@ -32,7 +32,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 function requireId(uuid: string | undefined): string {
   const id = uuid?.trim();
   if (!id) {
-    throw new Response("Not Found", { status: 404 });
+    throw new Response("Meetup not found", { status: 404 });
   }
   return id;
 }
@@ -40,7 +40,7 @@ function requireId(uuid: string | undefined): string {
 export const loader = async ({ params, context }: LoaderFunctionArgs) => {
   const meet = await find(getDatabaseUrl(context), requireId(params.uuid));
   if (!meet) {
-    throw new Response("Not Found", { status: 404 });
+    throw new Response("Meetup not found", { status: 404 });
   }
   return { meet };
 };

--- a/app/routes/m.$uuid.avails.tsx
+++ b/app/routes/m.$uuid.avails.tsx
@@ -1,11 +1,13 @@
 import { find, updateMeetAvails } from "@/api/services/meet";
+import { FormError } from "@/components/FormError";
 import { IconPencil } from "@/components/icons";
 import { SubmitButton } from "@/components/SubmitButton";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Input } from "@/components/ui/input";
 import { getDatabaseUrl } from "@/env";
-import { formatDay, parseDay } from "@/lib/dates";
+import { formatDay, parseDay, startOfToday } from "@/lib/dates";
+import { formErrorMessage } from "@/lib/form-errors";
 import type {
   ActionFunctionArgs,
   LoaderFunctionArgs,
@@ -46,49 +48,58 @@ export const loader = async ({ params, context }: LoaderFunctionArgs) => {
 const Avails = () => {
   const { meet } = useLoaderData<typeof loader>();
   const navigation = useNavigation();
-  const [, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const error = formErrorMessage(searchParams.get("error"));
 
   return (
-    <div className="flex w-full flex-col items-center gap-4 pt-20">
-      <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-3xl">
+    <div className="flex w-full min-w-0 flex-col items-center gap-6 pt-16">
+      <h1 className="w-full break-words text-center text-4xl font-extrabold tracking-tight">
         {meet.name}
       </h1>
-      <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">
-        Add your name
-      </h3>
-      <Form className="pb-4">
-        <div className="flex flex-row gap-4">
-          <Input name="group" type="text" placeholder="Name" />
+      <h2 className="text-2xl font-semibold tracking-tight">Add your name</h2>
+      <Form method="get" className="flex w-full flex-col gap-2">
+        <div className="flex flex-row items-center gap-3">
+          <label htmlFor="group-name" className="sr-only">
+            Your name
+          </label>
+          <Input
+            id="group-name"
+            name="group"
+            type="text"
+            placeholder="Name"
+            autoComplete="off"
+            autoCapitalize="words"
+            required
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? "name-error" : undefined}
+          />
           <SubmitButton
             text="Next"
             submitting={navigation.state === "submitting"}
             disabled={navigation.state === "loading"}
           />
         </div>
+        <FormError id="name-error" message={error} />
       </Form>
       {Object.keys(meet.availabilities).length !== 0 && (
-        <div className="w-full">
-          <h3 className="scroll-m-20 text-xl font-semibold tracking-tight pb-2">
+        <div className="w-full min-w-0">
+          <h2 className="pb-2 text-xl font-semibold tracking-tight">
             Returning?
-          </h3>
+          </h2>
           <div>
             {Object.keys(meet.availabilities).map((group) => {
               return (
                 <div key={group} className="py-1">
-                  <div className="flex flex-row items-center gap-4">
-                    <h4 className="scroll-m-20 text-lg tracking-tight">
+                  <div className="flex min-w-0 flex-row items-center gap-3">
+                    <p className="min-w-0 flex-1 break-words text-lg tracking-tight">
                       {group}
-                    </h4>
+                    </p>
                     <Button
                       variant="outline"
                       size="icon"
-                      onClick={() =>
-                        setSearchParams(
-                          new URLSearchParams({
-                            group: encodeURIComponent(group),
-                          }),
-                        )
-                      }
+                      type="button"
+                      aria-label={`Edit ${group}`}
+                      onClick={() => setSearchParams({ group })}
                     >
                       <IconPencil className="h-4 w-4" />
                     </Button>
@@ -111,38 +122,51 @@ export const action = async ({
   const id = requireId(params.uuid);
   const formData = await request.formData();
   const url = new URL(request.url);
-  const group = url.searchParams.get("group") ?? "";
+  const group = (url.searchParams.get("group") ?? "").trim();
   const dates = formData.get("dates")?.toString() ?? "";
 
-  await updateMeetAvails(
-    getDatabaseUrl(context),
-    id,
-    decodeURIComponent(group),
-    dates.split(",").filter(Boolean),
-  );
+  if (!group) {
+    return redirect(`/m/${id}/avails?error=name`, 303);
+  }
 
-  return redirect(`/m/${id}`);
+  try {
+    await updateMeetAvails(
+      getDatabaseUrl(context),
+      id,
+      group,
+      dates.split(",").filter(Boolean),
+    );
+  } catch (error) {
+    if (error instanceof Response) {
+      throw error;
+    }
+    return redirect(`/m/${id}/avails?group=${encodeURIComponent(group)}&error=save`, 303);
+  }
+
+  return redirect(`/m/${id}`, 303);
 };
 
 function AddAvails() {
   const { meet } = useLoaderData<typeof loader>();
   const [searchParams] = useSearchParams();
-  const decodedGroup = decodeURIComponent(searchParams.get("group") ?? "");
+  const decodedGroup = searchParams.get("group") ?? "";
   const dates = meet.availabilities[decodedGroup] ?? [];
+  const today = startOfToday();
   const [multiDates, setMultiDates] = React.useState<Date[] | undefined>(
     dates.map((date: { day: string }) => parseDay(date.day)),
   );
   const navigation = useNavigation();
+  const error = formErrorMessage(searchParams.get("error"));
 
   return (
-    <div className="flex w-full flex-col items-center gap-4 pt-20">
-      <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-3xl">
+    <div className="flex w-full min-w-0 flex-col items-center gap-6 pt-16">
+      <h1 className="w-full break-words text-center text-4xl font-extrabold tracking-tight">
         {meet.name}
       </h1>
-      <h4 className="scroll-m-20 pb-4 text-xl font-semibold tracking-tight">
+      <h2 className="w-full break-words text-center text-xl font-semibold tracking-tight">
         {`When are you free, ${decodedGroup}?`}
-      </h4>
-      <Form method="post">
+      </h2>
+      <Form method="post" className="w-full">
         <Input
           name="dates"
           className="hidden"
@@ -153,16 +177,20 @@ function AddAvails() {
           <Calendar
             mode="multiple"
             selected={multiDates}
-            onSelect={setMultiDates}
+            onSelect={(days) => {
+              const keptPast = (multiDates ?? []).filter((day) => day < today);
+              const next = (days ?? []).filter((day) => day >= today);
+              setMultiDates([...keptPast, ...next]);
+            }}
+            disabled={{ before: today }}
             className="rounded-md border"
           />
-          <div>
-            <SubmitButton
-              text="Save"
-              submitting={navigation.state === "submitting"}
-              disabled={navigation.state === "loading"}
-            />
-          </div>
+          <SubmitButton
+            text="Save"
+            submitting={navigation.state === "submitting"}
+            disabled={navigation.state === "loading"}
+          />
+          <FormError message={error} />
         </div>
       </Form>
     </div>
@@ -171,7 +199,8 @@ function AddAvails() {
 
 export default function Wrapper() {
   const [searchParams] = useSearchParams();
-  if (searchParams.has("group")) {
+  const group = searchParams.get("group");
+  if (group !== null && group.trim() !== "") {
     return <AddAvails />;
   }
   return <Avails />;

--- a/app/routes/m.$uuid.tsx
+++ b/app/routes/m.$uuid.tsx
@@ -18,7 +18,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 function requireId(uuid: string | undefined): string {
   const id = uuid?.trim();
   if (!id) {
-    throw new Response("Not Found", { status: 404 });
+    throw new Response("Meetup not found", { status: 404 });
   }
   return id;
 }
@@ -26,7 +26,7 @@ function requireId(uuid: string | undefined): string {
 export const loader = async ({ params, context }: LoaderFunctionArgs) => {
   const meet = await find(getDatabaseUrl(context), requireId(params.uuid));
   if (!meet) {
-    throw new Response("Not Found", { status: 404 });
+    throw new Response("Meetup not found", { status: 404 });
   }
   return { meet };
 };

--- a/app/routes/m.$uuid.tsx
+++ b/app/routes/m.$uuid.tsx
@@ -6,12 +6,7 @@ import { getDatabaseUrl } from "@/env";
 import { formatDayHeading } from "@/lib/dates";
 import { Availabilities } from "@/types";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
-import {
-  useLoaderData,
-  useNavigate,
-  useNavigation,
-  useParams,
-} from "react-router";
+import { Link, useLoaderData, useNavigation } from "react-router";
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
   return [
@@ -58,59 +53,52 @@ const availsByDate = (avails: Availabilities) => {
 export default function MeetupDetails() {
   const { meet } = useLoaderData<typeof loader>();
   const dates = availsByDate(meet.availabilities);
-  const params = useParams();
   const navigation = useNavigation();
-  const navigate = useNavigate();
   const respondentCount = Object.keys(meet.availabilities).length;
+  const busy = navigation.state !== "idle";
 
   return (
-    <div className="flex w-full flex-col items-center gap-4 pt-20">
-      <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-3xl">
+    <div className="flex w-full min-w-0 flex-col items-center gap-6 pt-16">
+      <h1 className="w-full break-words text-center text-4xl font-extrabold tracking-tight">
         {meet.name}
       </h1>
-      <div className="flex flex-row pb-4">
-        <div className="pr-4">
-          <Button
-            disabled={navigation.state === "loading"}
-            onClick={() => navigate(`/m/${params.uuid}/avails`)}
+      <div className="flex flex-row flex-wrap items-center justify-center gap-3">
+        <Button asChild>
+          <Link
+            to={`/m/${meet.uuid}/avails`}
+            className={busy ? "pointer-events-none opacity-50" : undefined}
           >
             Add Availability
-          </Button>
-        </div>
+          </Link>
+        </Button>
         <ShareButton params={{ meet }} />
       </div>
       {dates.length === 0 && (
-        <div className="w-full px-4">
-          <h5 className="pb-2">
-            <span className="font-semibold text-lg">
-              🎉 You&apos;re ready to schedule!
-            </span>
-          </h5>
-          <ul className="list-disc list-inside">
+        <div className="w-full">
+          <p className="pb-2 text-lg font-semibold">
+            🎉 You&apos;re ready to schedule!
+          </p>
+          <ul className="list-inside list-disc">
             <li>Click &apos;Add Availability&apos; to set days you are free</li>
             <li>Share this link with your friends so they can schedule</li>
           </ul>
         </div>
       )}
-      <div className="w-full pb-4">
+      <div className="w-full min-w-0">
         {dates.map((date) => (
           <div key={date.day} className="py-2">
-            <div className="flex flex-row items-center">
-              <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
+            <div className="flex flex-row flex-wrap items-center gap-2">
+              <h2 className="text-xl font-semibold tracking-tight">
                 {formatDayHeading(date.day)}
-              </h4>
-              <div className="pl-2">
-                <span className="text-xs">
-                  {`${date.groups.length} / ${respondentCount}`}
-                </span>
-              </div>
+              </h2>
+              <span className="text-xs text-muted-foreground">
+                {`${date.groups.length} / ${respondentCount}`}
+              </span>
               {date.groups.length === respondentCount && (
-                <div className="pl-2">
-                  <IconCheck />
-                </div>
+                <IconCheck className="text-green-600 dark:text-green-500" />
               )}
             </div>
-            <span>{date.groups.join(", ")}</span>
+            <p className="break-words">{date.groups.join(", ")}</p>
           </div>
         ))}
       </div>

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -20,13 +20,13 @@
     --secondary-foreground: 222.2 47.4% 11.2%;
 
     --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted-foreground: 215 16% 38%;
 
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 72% 40%;
+    --destructive-foreground: 0 0% 100%;
 
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
@@ -53,13 +53,13 @@
     --secondary-foreground: 210 40% 98%;
 
     --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted-foreground: 215 16% 72%;
 
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 72% 68%;
+    --destructive-foreground: 222.2 47.4% 11.2%;
 
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
@@ -71,7 +71,22 @@
   * {
     @apply border-border;
   }
+  :root {
+    color-scheme: light;
+  }
+  .dark,
+  :root[class~="dark"] {
+    color-scheme: dark;
+  }
+  html {
+    accent-color: hsl(var(--foreground));
+  }
   body {
     @apply bg-background text-foreground;
+    caret-color: hsl(var(--foreground));
+  }
+  ::selection {
+    background-color: hsl(var(--foreground) / 0.16);
+    color: hsl(var(--foreground));
   }
 }

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -27,7 +27,7 @@ function isHomepageGet(request: Request): boolean {
 }
 
 // Bump when homepage HTML or the theme boot script changes.
-const HOMEPAGE_CACHE_VERSION = "4";
+const HOMEPAGE_CACHE_VERSION = "5";
 
 function homepageCacheKey(request: Request): Request {
   const url = new URL("/", request.url);
@@ -45,6 +45,10 @@ function rewriteLegacyCreatePost(request: Request): Request {
   }
   const url = new URL(request.url);
   if (url.pathname !== "/") {
+    return request;
+  }
+  // RR index actions post to /?index. Leave those on the homepage route.
+  if (url.searchParams.has("index")) {
     return request;
   }
   url.pathname = "/create";

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -26,7 +26,7 @@ function isHomepageGet(request: Request): boolean {
 }
 
 // Bump when homepage HTML or the theme boot script changes.
-const HOMEPAGE_CACHE_VERSION = "2";
+const HOMEPAGE_CACHE_VERSION = "3";
 
 function homepageCacheKey(request: Request): Request {
   const url = new URL("/", request.url);
@@ -38,12 +38,24 @@ function edgeCache(): Cache {
   return (caches as unknown as { default: Cache }).default;
 }
 
+function rewriteLegacyCreatePost(request: Request): Request {
+  if (request.method !== "POST") {
+    return request;
+  }
+  const url = new URL(request.url);
+  if (url.pathname !== "/") {
+    return request;
+  }
+  url.pathname = "/create";
+  return new Request(url, request);
+}
+
 export default {
   async fetch(request, env, ctx) {
     const loadContext = { cloudflare: { env, ctx } };
 
     if (!isHomepageGet(request)) {
-      return requestHandler(request, loadContext);
+      return requestHandler(rewriteLegacyCreatePost(request), loadContext);
     }
 
     const cache = edgeCache();

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -19,14 +19,15 @@ const HOMEPAGE_CACHE_CONTROL =
   "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800";
 
 function isHomepageGet(request: Request): boolean {
-  if (request.method !== "GET" && request.method !== "HEAD") {
+  if (request.method !== "GET") {
     return false;
   }
-  return new URL(request.url).pathname === "/";
+  const url = new URL(request.url);
+  return url.pathname === "/" && url.search === "";
 }
 
 // Bump when homepage HTML or the theme boot script changes.
-const HOMEPAGE_CACHE_VERSION = "3";
+const HOMEPAGE_CACHE_VERSION = "4";
 
 function homepageCacheKey(request: Request): Request {
   const url = new URL("/", request.url);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,6 +18,11 @@
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1
+  },
+  "assets": {
+    // POST /create must reach the Worker. A static `/` HTML asset 405s
+    // document form posts that stay on `/`.
+    "run_worker_first": ["/", "/create"]
   }
   // DATABASE_URL is a Worker secret. Do not put it in `vars`.
   //   npx wrangler secret put DATABASE_URL


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refinement only. Same product, same `/m/:id` URLs, same Neon schema.

Rebased onto latest main after theme PR #11 landed. Theme follow-system is already on main and is not re-implemented here. ModeToggle only gets a 44px hit area and an aria-label.

## What changed

**Create cannot 405.** A document POST to `/` was hitting the root route (no action). Cached homepage HTML also posts to `/`. The form now posts to `/?index` so the homepage action runs. The Worker rewrites a stale POST `/` (no `index` param) to `/create`. `run_worker_first` covers `/` and `/create`. Homepage cache key is `5`. HEAD and `?error=` requests are not stored as the homepage GET.

**Missing meet stays 404.** `find` already returns null. Meet loaders throw 404. The error page uses the response text, so a missing meet says "Meetup not found" and a random 404 does not.

**Empty create name.** Whitespace-only names show an inline "Enter a name." JS forms stay on `/` via action data. No-JS `/create` redirects to `/?error=name`. Create/save failures show a short retry message instead of a blank 400.

**Calendar.** Past days are disabled. Already-saved past days stay selected so a later Save does not wipe them.

**About.** Restored as an overlay (same copy), not a `<details>` dropdown. Small equivalent panel, not Radix, so the homepage chunk stays ~2.6 kB.

**A11y and type.** Home is `h1` + `p`. Real `h2`s on meet/avails. Labels on the name fields. 44px targets on Create, Add Availability, calendar days, and the theme toggle. Long meetup and participant names wrap.

**Tokens.** Placeholder contrast, selection/caret/accent from the palette, `color-scheme` so native widgets match. Footer icons share a 44px hit area.

## Left alone on purpose

- Theme follow-system from #11 (already on main)
- No accounts, time-of-day, delete-meetup, email, or new product pages
- Public `/m/:id` URLs and the Neon `meet` table
- No Inter / purple gradient / card-in-card
- No extra motion
- "We've Moved" banner stays gone (the RR7 cut already dropped it)
- Server does not strip past days on save. A UTC Worker would reject "today" for people west of UTC.

## Checks

- `npm run typecheck`, `lint`, and `build` pass
- Do not deploy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6e26c13-9761-461e-9234-6dca027692cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6e26c13-9761-461e-9234-6dca027692cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

