### PR TITLE
Ship cream paper and pigment cobalt

### DIFF
--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-muted-foreground underline-offset-4 hover:text-foreground hover:underline",
       },
       size: {
         default: "h-11 min-h-11 px-4 py-2",

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-11 min-h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base caret-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-11 min-h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base caret-primary ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -81,6 +81,7 @@
   }
   html {
     accent-color: oklch(var(--primary));
+    scrollbar-color: oklch(var(--border)) oklch(var(--background));
   }
   body {
     @apply bg-background text-foreground;

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -4,66 +4,67 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* Canvas: cream paper. Ink: near-black. Action: pigment cobalt. */
+    --background: 0.95 0.014 85;
+    --foreground: 0.212 0.01 67;
 
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card: 0.95 0.014 85;
+    --card-foreground: 0.212 0.01 67;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover: 0.95 0.014 85;
+    --popover-foreground: 0.212 0.01 67;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 0.48 0.16 264;
+    --primary-foreground: 0.95 0.014 85;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 0.91 0.018 82;
+    --secondary-foreground: 0.212 0.01 67;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215 16% 38%;
+    --muted: 0.91 0.018 82;
+    --muted-foreground: 0.47 0.03 70;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 0.9 0.02 80;
+    --accent-foreground: 0.212 0.01 67;
 
-    --destructive: 0 72% 40%;
-    --destructive-foreground: 0 0% 100%;
+    --destructive: 0.5 0.17 25;
+    --destructive-foreground: 0.95 0.014 85;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 0.86 0.02 80;
+    --input: 0.86 0.02 80;
+    --ring: 0.48 0.16 264;
 
     --radius: 0.5rem;
   }
 
   .dark,
   :root[class~="dark"] {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    --background: 0.24 0.012 70;
+    --foreground: 0.95 0.014 85;
 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
+    --card: 0.24 0.012 70;
+    --card-foreground: 0.95 0.014 85;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 0.24 0.012 70;
+    --popover-foreground: 0.95 0.014 85;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 0.67 0.13 264;
+    --primary-foreground: 0.212 0.01 67;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 0.3 0.014 70;
+    --secondary-foreground: 0.95 0.014 85;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 16% 72%;
+    --muted: 0.3 0.014 70;
+    --muted-foreground: 0.74 0.02 80;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 0.32 0.016 70;
+    --accent-foreground: 0.95 0.014 85;
 
-    --destructive: 0 72% 68%;
-    --destructive-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0.7 0.13 27;
+    --destructive-foreground: 0.212 0.01 67;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --border: 0.38 0.018 70;
+    --input: 0.38 0.018 70;
+    --ring: 0.67 0.13 264;
   }
 }
 
@@ -79,14 +80,14 @@
     color-scheme: dark;
   }
   html {
-    accent-color: hsl(var(--foreground));
+    accent-color: oklch(var(--primary));
   }
   body {
     @apply bg-background text-foreground;
-    caret-color: hsl(var(--foreground));
+    caret-color: oklch(var(--primary));
   }
   ::selection {
-    background-color: hsl(var(--foreground) / 0.16);
-    color: hsl(var(--foreground));
+    background-color: oklch(var(--primary) / 0.22);
+    color: oklch(var(--foreground));
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,38 +13,38 @@ module.exports = {
     },
     extend: {
       colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        border: "oklch(var(--border))",
+        input: "oklch(var(--input))",
+        ring: "oklch(var(--ring))",
+        background: "oklch(var(--background))",
+        foreground: "oklch(var(--foreground))",
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
+          DEFAULT: "oklch(var(--primary))",
+          foreground: "oklch(var(--primary-foreground))",
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
+          DEFAULT: "oklch(var(--secondary))",
+          foreground: "oklch(var(--secondary-foreground))",
         },
         destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
+          DEFAULT: "oklch(var(--destructive))",
+          foreground: "oklch(var(--destructive-foreground))",
         },
         muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
+          DEFAULT: "oklch(var(--muted))",
+          foreground: "oklch(var(--muted-foreground))",
         },
         accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
+          DEFAULT: "oklch(var(--accent))",
+          foreground: "oklch(var(--accent-foreground))",
         },
         popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
+          DEFAULT: "oklch(var(--popover))",
+          foreground: "oklch(var(--popover-foreground))",
         },
         card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
+          DEFAULT: "oklch(var(--card))",
+          foreground: "oklch(var(--card-foreground))",
         },
       },
       borderRadius: {

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -26,8 +26,8 @@ function isHomepageGet(request: Request): boolean {
   return url.pathname === "/" && url.search === "";
 }
 
-// Bump when homepage HTML or the theme boot script changes.
-const HOMEPAGE_CACHE_VERSION = "5";
+// Bump when homepage HTML, CSS tokens, or the theme boot script changes.
+const HOMEPAGE_CACHE_VERSION = "6";
 
 function homepageCacheKey(request: Request): Request {
   const url = new URL("/", request.url);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge. Do not deploy.

Color-only production pass. Type, layout, copy, calendar, buttons, and radius stay put. No preview routes, no screenshot fixture.

## The blue

Light: `oklch(0.48 0.16 264)` `#2D56B6`
Dark: `oklch(0.67 0.13 264)` `#6C93E5`

`#1E4BFF` is `oklch(0.52 0.27 265)` with the blue channel pinned at 255. That is screen-primary, not pigment. This cobalt keeps the same hue family (a calendar mark, "you're free") and cuts chroma so it sits inside the gamut. Light mode is a hair deeper. Dark mode lifts the same hue so focus still hits 3:1 on warm dark paper. `#1E4BFF` fails that (2.8:1).

Button lettering is cream on light cobalt and ink on dark cobalt, not generic white or gray.

## Roles (Operate)

Cobalt is scarce. It is Create, Next, Save, Add Availability, selected days, focus rings, caret, accent-color, and selection wash.

About, GitHub, theme toggle, Share, hairlines, and the WAYF wordmark stay ink or muted. The link variant no longer uses `text-primary`, so secondary links cannot steal the action color from Create.

## Files

- `app/tailwind.css` tokens (OKLCH) plus selection, caret, accent-color, scrollbars
- `tailwind.config.js` `hsl` to `oklch`
- `app/components/ui/button.tsx` link variant is muted ink
- `app/components/ui/input.tsx` caret from primary
- `workers/app.ts` homepage cache key `6`

Followed official Impeccable 4.1.1 `/impeccable colorize` (Operate) and craft floor after `npx impeccable install`. Palette verified WCAG AA on cream and on dark paper.

`npm run typecheck`, `lint`, and `build` pass.

`/impeccable init` is still available if we want PRODUCT.md later. This PR does not add it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea303201-d06e-4d54-900f-6dfed1ec8e8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea303201-d06e-4d54-900f-6dfed1ec8e8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

