### PR TITLE
Ship Slate as the dark-mode canvas

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -49,7 +49,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         />
         <meta
           name="theme-color"
-          content="#231E19"
+          content="#0D1218"
           media="(prefers-color-scheme: dark)"
         />
         <Meta />

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -38,32 +38,32 @@
 
   .dark,
   :root[class~="dark"] {
-    --background: 0.24 0.012 70;
+    --background: 0.18 0.014 250;
     --foreground: 0.95 0.014 85;
 
-    --card: 0.24 0.012 70;
+    --card: 0.18 0.014 250;
     --card-foreground: 0.95 0.014 85;
 
-    --popover: 0.24 0.012 70;
+    --popover: 0.18 0.014 250;
     --popover-foreground: 0.95 0.014 85;
 
     --primary: 0.67 0.13 264;
     --primary-foreground: 0.212 0.01 67;
 
-    --secondary: 0.3 0.014 70;
+    --secondary: 0.24 0.016 250;
     --secondary-foreground: 0.95 0.014 85;
 
-    --muted: 0.3 0.014 70;
+    --muted: 0.24 0.016 250;
     --muted-foreground: 0.74 0.02 80;
 
-    --accent: 0.32 0.016 70;
+    --accent: 0.26 0.018 250;
     --accent-foreground: 0.95 0.014 85;
 
     --destructive: 0.7 0.13 27;
     --destructive-foreground: 0.212 0.01 67;
 
-    --border: 0.38 0.018 70;
-    --input: 0.38 0.018 70;
+    --border: 0.34 0.02 250;
+    --input: 0.34 0.02 250;
     --ring: 0.67 0.13 264;
   }
 }

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -33,7 +33,7 @@ function isHomepageGet(request: Request): boolean {
 }
 
 // Bump when homepage HTML, CSS tokens, or the theme boot script changes.
-const HOMEPAGE_CACHE_VERSION = "10";
+const HOMEPAGE_CACHE_VERSION = "11";
 
 function homepageCacheKey(request: Request): Request {
   const url = new URL("/", request.url);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Andrew picked Slate from the Ink / Navy / Slate dark mocks. Light cream stays put.

Dark surfaces in `app/tailwind.css` move from warm brown (`0.24 0.012 70`) to hue-250 Slate. Cream ink, pigment cobalt, and `--destructive` are unchanged. Light `:root` tokens are unchanged.

Dark `theme-color` in `app/root.tsx` is `#0D1218` instead of `#231E19`. Light stays `#F3EEE4`.

`HOMEPAGE_CACHE_VERSION` is 11, on top of the sans OG merge (`006e079`).

OG image, wayf-mark, copy, type, and layout are untouched.

Do not merge or deploy from this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4d12053-3ab3-4626-982b-5f228276ef10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4d12053-3ab3-4626-982b-5f228276ef10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

