### PR TITLE
Deploy Worker `wayf` from GitHub Actions on main

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,27 @@
+name: Deploy Worker
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy to Cloudflare
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: a37e69b6453658a6c25114e555343393
+          command: deploy --keep-vars

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ npx wrangler secret put DATABASE_URL
 npm run deploy
 ```
 
+Merges to `main` deploy the Worker via `.github/workflows/deploy-worker.yml` (repo secret `CLOUDFLARE_API_TOKEN`).
+
 `npm run deploy` runs `react-router build` then `wrangler deploy`. That overwrites the existing account Worker named `wayf` (id `e5e1317519674e49aaab82528e6ab10a`).
 
 Public hosts already attached to that Worker:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pushes to `main` (and manual `workflow_dispatch`) now build and deploy the existing Cloudflare Worker `wayf`.

- Adds `.github/workflows/deploy-worker.yml` using `cloudflare/wrangler-action@v3`
- Uses `--keep-vars` so the Worker secret `DATABASE_URL` is not wiped
- Account id is hardcoded; only repo secret needed is `CLOUDFLARE_API_TOKEN`
- One-line README note under the deploy section

Does not change app code, wrangler routes, or tokens. Does not deploy from this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14b98b63-a52b-4ace-a199-cb9a972bb6d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14b98b63-a52b-4ace-a199-cb9a972bb6d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

