### PR TITLE
Document Workers Builds auto-deploy for wayf

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npx wrangler secret put DATABASE_URL
 npm run deploy
 ```
 
-`npm run deploy` runs `react-router build` then `wrangler deploy`. That overwrites the existing account Worker named `wayf` (id `e5e1317519674e49aaab82528e6ab10a`).
+`npm run deploy` runs `react-router build` then `wrangler deploy`. That overwrites the existing account Worker named `wayf` (id `e5e1317519674e49aaab82528e6ab10a`). Merges to `main` auto-deploy the `wayf` Worker via Cloudflare Workers Builds (PR branches get preview versions).
 
 Public hosts already attached to that Worker:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only note in the existing Cloudflare deploy section: merges to `main` auto-deploy the `wayf` Worker via Cloudflare Workers Builds, and PR branches get preview versions.

No app, Wrangler, token, or GitHub Action changes. Do not merge unless you want this sentence on `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8b759b3-b20a-4ef9-afbe-3b1058746cab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8b759b3-b20a-4ef9-afbe-3b1058746cab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

