### PR TITLE
Stop serving stale homepage HTML after a Worker deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ This rewrite:
 
 - SSR on Cloudflare Workers (official Vite plugin path, not Pages)
 - Neon via HTTP (`drizzle-orm/neon-http`), same schema
-- Homepage GET is static: no Neon, no session. Cached at the edge (`caches.default`, 1 day, stale-while-revalidate 1 week)
+- Homepage GET is static: no Neon, no session. Cached at the edge (`caches.default`) keyed by the production build id and hashed CSS URL. Browsers get `max-age=0, must-revalidate` so a reload after deploy cannot keep HTML that points at deleted `/assets/*` files.
 - Neon HTTP client is reused per Worker isolate. Create and save availability are one query each, then redirect
 - Dead Supabase, Remix Node server, Sentry upload, and Vercel analytics removed

--- a/app/globals.d.ts
+++ b/app/globals.d.ts
@@ -3,6 +3,8 @@
 export {};
 
 declare global {
+  const __WAYF_HOMEPAGE_CACHE_ID__: string;
+
   interface Env {
     DATABASE_URL?: string;
     // Legacy Hono Worker used this name in .env.example.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,29 @@
+import { execSync } from "node:child_process";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
+function homepageCacheId(): string {
+  const fromCi =
+    process.env.WORKERS_CI_BUILD_UUID ?? process.env.WORKERS_CI_COMMIT_SHA;
+  if (fromCi) {
+    return fromCi;
+  }
+  try {
+    return execSync("git rev-parse HEAD", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "dev";
+  }
+}
+
 export default defineConfig({
+  define: {
+    __WAYF_HOMEPAGE_CACHE_ID__: JSON.stringify(homepageCacheId()),
+  },
   plugins: [
     cloudflare({ viteEnvironment: { name: "ssr" } }),
     reactRouter(),

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -4,6 +4,7 @@ import {
   markdownResponse,
   wantsMarkdown,
 } from "@/lib/markdown";
+import homepageStylesheet from "@/tailwind.css?url";
 import { createRequestHandler } from "react-router";
 
 declare module "react-router" {
@@ -21,8 +22,13 @@ const requestHandler = createRequestHandler(
   import.meta.env.MODE,
 );
 
-const HOMEPAGE_CACHE_CONTROL =
-  "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800";
+// Browsers must revalidate HTML after a deploy so they cannot keep a
+// document that points at deleted hashed /assets/* files.
+const HOMEPAGE_BROWSER_CACHE_CONTROL = "public, max-age=0, must-revalidate";
+// caches.default honors Cache-Control on put(). max-age=0 makes put() fail
+// (413) or match() miss, so the stored copy uses a long TTL. Invalidation is
+// the build-scoped cache key, not this header.
+const HOMEPAGE_EDGE_CACHE_CONTROL = "public, max-age=86400";
 
 function isHomepageGet(request: Request): boolean {
   if (request.method !== "GET") {
@@ -32,13 +38,23 @@ function isHomepageGet(request: Request): boolean {
   return url.pathname === "/" && url.search === "";
 }
 
-// Bump when homepage HTML, CSS tokens, or the theme boot script changes.
-const HOMEPAGE_CACHE_VERSION = "11";
-
 function homepageCacheKey(request: Request): Request {
   const url = new URL("/", request.url);
-  url.searchParams.set("v", HOMEPAGE_CACHE_VERSION);
+  url.searchParams.set(
+    "v",
+    `${__WAYF_HOMEPAGE_CACHE_ID__}:${homepageStylesheet}`,
+  );
   return new Request(url.href, { method: "GET" });
+}
+
+function withCacheControl(response: Response, cacheControl: string): Response {
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", cacheControl);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 function edgeCache(): Cache {
@@ -107,7 +123,7 @@ export default {
     const cacheKey = homepageCacheKey(request);
     const cached = await cache.match(cacheKey);
     if (cached) {
-      return cached;
+      return withCacheControl(cached, HOMEPAGE_BROWSER_CACHE_CONTROL);
     }
 
     const response = await requestHandler(request, loadContext);
@@ -116,7 +132,7 @@ export default {
     }
 
     const headers = new Headers(response.headers);
-    headers.set("Cache-Control", HOMEPAGE_CACHE_CONTROL);
+    headers.set("Cache-Control", HOMEPAGE_EDGE_CACHE_CONTROL);
     headers.append("Vary", "Accept, Accept-Encoding");
     const cacheable = new Response(response.body, {
       status: response.status,
@@ -124,6 +140,6 @@ export default {
       headers,
     });
     ctx.waitUntil(cache.put(cacheKey, cacheable.clone()));
-    return cacheable;
+    return withCacheControl(cacheable, HOMEPAGE_BROWSER_CACHE_CONTROL);
   },
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`caches.default` is not scoped to a Worker version. Homepage GET HTML was stored under a hand-bumped `HOMEPAGE_CACHE_VERSION` and shipped with `max-age=3600` plus a week of `stale-while-revalidate`. After a deploy, old hashed `/assets/tailwind-*.css` files are gone, so a cache HIT (or a browser reload of cached HTML) 404s the stylesheet until a later refresh.

This drops the manual version and keys the Cache API entry with a Vite-inlined build id plus the hashed CSS URL. Production Workers Builds use `WORKERS_CI_BUILD_UUID` (then `WORKERS_CI_COMMIT_SHA`). Local and `wrangler deploy` builds use `git rev-parse HEAD`. The CSS import is the same hashed `/assets/tailwind-*.css` path the document will request.

Browsers now get `Cache-Control: public, max-age=0, must-revalidate` on the HTML document. Hashed `/assets/*` are unchanged. The copy stored in `caches.default` still uses a 1-day TTL so `put()` is allowed (`max-age=0` makes Cache API `put()` fail). A new deploy cannot match the old key.

No UI, route, or GitHub Action changes. Not deployed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77fd7bda-5108-41e8-9cc0-d04ca070dcd3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77fd7bda-5108-41e8-9cc0-d04ca070dcd3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

