### PR TITLE
Drop homepage Cache API and Vite build-id define

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ This rewrite:
 
 - SSR on Cloudflare Workers (official Vite plugin path, not Pages)
 - Neon via HTTP (`drizzle-orm/neon-http`), same schema
-- Homepage GET is static: no Neon, no session. Cached at the edge (`caches.default`) keyed by the production build id and hashed CSS URL. Browsers get `max-age=0, must-revalidate` so a reload after deploy cannot keep HTML that points at deleted `/assets/*` files.
+- Homepage GET is static: no Neon, no session. HTML is `Cache-Control: public, max-age=0, must-revalidate` so browsers do not keep a document that points at deleted hashed `/assets/*` files. Vite already fingerprints those assets.
 - Neon HTTP client is reused per Worker isolate. Create and save availability are one query each, then redirect
 - Dead Supabase, Remix Node server, Sentry upload, and Vercel analytics removed

--- a/app/globals.d.ts
+++ b/app/globals.d.ts
@@ -3,8 +3,6 @@
 export {};
 
 declare global {
-  const __WAYF_HOMEPAGE_CACHE_ID__: string;
-
   interface Env {
     DATABASE_URL?: string;
     // Legacy Hono Worker used this name in .env.example.

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -5,7 +5,11 @@ import { Input } from "@/components/ui/input";
 import { createMeetupAction } from "@/lib/create-meetup.server";
 import { formErrorMessage } from "@/lib/form-errors";
 import { homeMeta } from "@/lib/seo";
-import type { ActionFunctionArgs, MetaFunction } from "react-router";
+import type {
+  ActionFunctionArgs,
+  HeadersFunction,
+  MetaFunction,
+} from "react-router";
 import {
   Form,
   useActionData,
@@ -14,6 +18,10 @@ import {
 } from "react-router";
 
 export const meta: MetaFunction = () => homeMeta();
+
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "public, max-age=0, must-revalidate",
+});
 
 export const action = async ({ request, context }: ActionFunctionArgs) => {
   return createMeetupAction(request, context);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,29 +1,9 @@
-import { execSync } from "node:child_process";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-function homepageCacheId(): string {
-  const fromCi =
-    process.env.WORKERS_CI_BUILD_UUID ?? process.env.WORKERS_CI_COMMIT_SHA;
-  if (fromCi) {
-    return fromCi;
-  }
-  try {
-    return execSync("git rev-parse HEAD", {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return "dev";
-  }
-}
-
 export default defineConfig({
-  define: {
-    __WAYF_HOMEPAGE_CACHE_ID__: JSON.stringify(homepageCacheId()),
-  },
   plugins: [
     cloudflare({ viteEnvironment: { name: "ssr" } }),
     reactRouter(),

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -4,7 +4,6 @@ import {
   markdownResponse,
   wantsMarkdown,
 } from "@/lib/markdown";
-import homepageStylesheet from "@/tailwind.css?url";
 import { createRequestHandler } from "react-router";
 
 declare module "react-router" {
@@ -21,45 +20,6 @@ const requestHandler = createRequestHandler(
   () => import("virtual:react-router/server-build"),
   import.meta.env.MODE,
 );
-
-// Browsers must revalidate HTML after a deploy so they cannot keep a
-// document that points at deleted hashed /assets/* files.
-const HOMEPAGE_BROWSER_CACHE_CONTROL = "public, max-age=0, must-revalidate";
-// caches.default honors Cache-Control on put(). max-age=0 makes put() fail
-// (413) or match() miss, so the stored copy uses a long TTL. Invalidation is
-// the build-scoped cache key, not this header.
-const HOMEPAGE_EDGE_CACHE_CONTROL = "public, max-age=86400";
-
-function isHomepageGet(request: Request): boolean {
-  if (request.method !== "GET") {
-    return false;
-  }
-  const url = new URL(request.url);
-  return url.pathname === "/" && url.search === "";
-}
-
-function homepageCacheKey(request: Request): Request {
-  const url = new URL("/", request.url);
-  url.searchParams.set(
-    "v",
-    `${__WAYF_HOMEPAGE_CACHE_ID__}:${homepageStylesheet}`,
-  );
-  return new Request(url.href, { method: "GET" });
-}
-
-function withCacheControl(response: Response, cacheControl: string): Response {
-  const headers = new Headers(response.headers);
-  headers.set("Cache-Control", cacheControl);
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-}
-
-function edgeCache(): Cache {
-  return (caches as unknown as { default: Cache }).default;
-}
 
 function withMeetRobots(request: Request, response: Response): Response {
   const path = new URL(request.url).pathname;
@@ -112,34 +72,9 @@ export default {
       return withMeetRobots(request, markdown);
     }
 
-    if (!isHomepageGet(request)) {
-      return withMeetRobots(
-        request,
-        await requestHandler(rewriteLegacyCreatePost(request), loadContext),
-      );
-    }
-
-    const cache = edgeCache();
-    const cacheKey = homepageCacheKey(request);
-    const cached = await cache.match(cacheKey);
-    if (cached) {
-      return withCacheControl(cached, HOMEPAGE_BROWSER_CACHE_CONTROL);
-    }
-
-    const response = await requestHandler(request, loadContext);
-    if (response.status !== 200) {
-      return response;
-    }
-
-    const headers = new Headers(response.headers);
-    headers.set("Cache-Control", HOMEPAGE_EDGE_CACHE_CONTROL);
-    headers.append("Vary", "Accept, Accept-Encoding");
-    const cacheable = new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
-    ctx.waitUntil(cache.put(cacheKey, cacheable.clone()));
-    return withCacheControl(cacheable, HOMEPAGE_BROWSER_CACHE_CONTROL);
+    return withMeetRobots(
+      request,
+      await requestHandler(rewriteLegacyCreatePost(request), loadContext),
+    );
   },
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Andrew said the post-deploy unstyled flash is rare (he hardly ships) and he does not want custom unmaintainable plumbing. This removes that plumbing and keeps one standard header.

**Gone**
- Vite `define` `__WAYF_HOMEPAGE_CACHE_ID__` and `homepageCacheId()` / `git rev-parse` in `vite.config.ts`
- `declare const __WAYF_HOMEPAGE_CACHE_ID__` in `app/globals.d.ts`
- `caches.default` homepage GET cache in `workers/app.ts` (cache key, match/put, dual Cache-Control rewrite, `homepageStylesheet` import used only for the key)

**Kept**
- Home route `headers` export: `Cache-Control: public, max-age=0, must-revalidate` so browsers do not keep HTML that points at deleted hashed `/assets/*`
- Hashed `/assets/*` as Vite already emits them
- Markdown negotiation, `/create` POST rewrite, meet robots, `run_worker_first`

Homepage GET now uses the same `requestHandler` path as other GETs. No Cache API, no second TTL for `put()`.

Do not merge or deploy from this PR unless you want to.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c7ac931-0e70-43a6-9442-e8acb0771fd9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c7ac931-0e70-43a6-9442-e8acb0771fd9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

