### PR TITLE
fix(ui): keep selected days and submit width stable

### DIFF
--- a/app/components/SubmitButton.tsx
+++ b/app/components/SubmitButton.tsx
@@ -13,11 +13,14 @@ export function SubmitButton({
   return (
     <Button
       type="submit"
-      aria-disabled={submitting}
+      aria-busy={submitting || undefined}
       disabled={submitting || disabled}
+      className="relative"
     >
-      {submitting && <IconSpinner className="mr-2 h-4 w-4 animate-spin" />}
-      {text}
+      <span className={submitting ? "invisible" : undefined}>{text}</span>
+      {submitting ? (
+        <IconSpinner className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 animate-spin" />
+      ) : null}
     </Button>
   );
 }

--- a/app/components/ui/calendar.tsx
+++ b/app/components/ui/calendar.tsx
@@ -34,7 +34,7 @@ function Calendar({
         head_cell:
           "text-muted-foreground rounded-md w-11 font-normal text-[0.8rem]",
         row: "flex w-full mt-2",
-        cell: "h-11 w-11 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        cell: "h-11 w-11 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
           buttonVariants({ variant: "ghost" }),
           "h-11 w-11 p-0 font-normal aria-selected:opacity-100",
@@ -44,8 +44,9 @@ function Calendar({
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
         day_today: "bg-accent text-accent-foreground",
         day_outside:
-          "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
-        day_disabled: "text-muted-foreground opacity-50",
+          "day-outside text-muted-foreground opacity-50 aria-selected:bg-primary aria-selected:text-primary-foreground aria-selected:opacity-100",
+        day_disabled:
+          "text-muted-foreground opacity-50 aria-selected:bg-primary aria-selected:text-primary-foreground aria-selected:opacity-100",
         day_range_middle:
           "aria-selected:bg-accent aria-selected:text-accent-foreground",
         day_hidden: "invisible",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Selected days in the adjacent month were hard to read. `day_outside` muted cobalt and used gray type on a washed fill.

Create, Next, and Save grew when a spinner entered the layout. Fast submits made that jump obvious.

Selected and marked days stay the primary treatment. Unselected outside-month days stay muted so you can still see which month is in focus.

## Scope

`app/components/ui/calendar.tsx` (`day_outside`, `day_disabled`, and the selected-outside cell tint). Selected days use `bg-primary` and `text-primary-foreground` at full opacity, including disabled past days that stay selected.

`app/components/SubmitButton.tsx`. The idle label keeps the width. Busy state sets `aria-busy`, hides the label, and overlays the existing spinner.

Out of scope: color tokens, About link color, Create/Save idle styling.

## Tradeoffs

The spinner no longer sits beside the label. Width stays put. The label is gone for the short busy interval.

## Blast Radius

Every `Calendar` and every `SubmitButton` (Create, Next, Save). Light and dark both use the existing primary tokens, including dark `primary-foreground` ink on cobalt.

## Verification

control-ui plus computed styles on the real `Calendar` and `SubmitButton` (September 2026, Aug 31 selected next to Sep 1).

Light selected Aug 31 and Sep 1: `background-color: oklch(0.48 0.16 264)`, `color: oklch(0.95 0.014 85)`, `opacity: 1`. Unselected Oct 1 stays muted (`oklch(0.47 0.03 70)` at opacity 0.5). Unselected Sep 3 is ink.

Dark selected Aug 31 and Sep 1: `background-color: oklch(0.67 0.13 264)`, `color: oklch(0.212 0.01 67)`, `opacity: 1`. Same cobalt, dark ink on it. Not gray-on-muted-blue. Not cream-on-cream. Unselected Oct 1 stays muted cream-gray at opacity 0.5.

Idle vs pending Save `getBoundingClientRect().width`: both 62.5625px.

[Light September grid: selected Aug 31 matches in-month cobalt](https://cursor.com/agents/bc-4d652745-c007-46ad-afdf-50924f1ba600/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flight_calendar_and_save.png)
[Dark September grid: selected Aug 31 matches in-month cobalt](https://cursor.com/agents/bc-4d652745-c007-46ad-afdf-50924f1ba600/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdark_calendar_and_save.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d652745-c007-46ad-afdf-50924f1ba600?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d652745-c007-46ad-afdf-50924f1ba600&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

