### PR TITLE
Center Create/Save loading spinner

### DIFF
--- a/app/components/SubmitButton.tsx
+++ b/app/components/SubmitButton.tsx
@@ -19,7 +19,12 @@ export function SubmitButton({
     >
       <span className={submitting ? "invisible" : undefined}>{text}</span>
       {submitting ? (
-        <IconSpinner className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 animate-spin" />
+        <span
+          className="absolute inset-0 flex items-center justify-center"
+          aria-hidden
+        >
+          <IconSpinner className="h-4 w-4 animate-spin" />
+        </span>
       ) : null}
     </Button>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`animate-spin` applies `transform: rotate()`, which replaced the `-translate-x/y-1/2` used to center `IconSpinner`. The spinner’s top-left sat on the button center (down and to the right).

Keep the invisible idle label so Create/Save width stays stable. Overlay a full-button flex wrapper for centering; spin only the inner icon.

No color/type/hierarchy changes. No dep bumps.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbadfc79-6411-4f55-9059-dfd3d3ba1a0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbadfc79-6411-4f55-9059-dfd3d3ba1a0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

