### PR TITLE
Weekly dependency maintenance (wrangler 4.129, React 19.2.8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,30 +7,30 @@
       "name": "wayf",
       "dependencies": {
         "@neondatabase/serverless": "^1.1.0",
-        "@posthog/react": "^1.10.5",
+        "@posthog/react": "^1.10.6",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toast": "^1.1.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "isbot": "^5.2.2",
-        "posthog-js": "^1.424.1",
-        "react": "^19.2.7",
+        "posthog-js": "^1.427.3",
+        "react": "^19.2.8",
         "react-day-picker": "^8.10.2",
-        "react-dom": "^19.2.7",
+        "react-dom": "^19.2.8",
         "react-router": "8.3.1",
         "tailwind-merge": "^2.6.1",
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
-        "@cloudflare/vite-plugin": "^1.54.2",
+        "@cloudflare/vite-plugin": "^1.54.4",
         "@react-router/dev": "8.3.1",
-        "@types/node": "^26.4.0",
-        "@types/react": "^19.2.7",
-        "@types/react-dom": "^19.2.3",
+        "@types/node": "^26.4.1",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.7",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
         "@typescript-eslint/parser": "^6.7.4",
-        "autoprefixer": "^10.5.4",
+        "autoprefixer": "^10.5.5",
         "dotenv": "^16.6.1",
         "drizzle-kit": "^0.31.10",
         "eslint": "^8.38.0",
@@ -45,7 +45,7 @@
         "typescript": "^5.9.3",
         "vite": "^8.2.2",
         "vite-tsconfig-paths": "^5.1.4",
-        "wrangler": "^4.127.1"
+        "wrangler": "^4.129.0"
       },
       "engines": {
         "node": ">=22.22.0"
@@ -350,17 +350,17 @@
       }
     },
     "node_modules/@cloudflare/vite-plugin": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.54.2.tgz",
-      "integrity": "sha512-15mH5ARHTkNZAqa5GhedjLAt/MCiGBEo09Hgf82EiWuIm/5yOaMVL6ABSun/W8C3Vbw1clzW/2i9IfH5zT/Kvg==",
+      "version": "1.54.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.54.4.tgz",
+      "integrity": "sha512-UkwrW3lcjm9dbRnOyWr8M5e5GzdVLGd6Tz92qk1K7XOE5uEuuE4BtfnfNlKe9IoimZijqsU3Bwdlyxhquk1yMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cloudflare/unenv-preset": "2.16.1",
-        "miniflare": "5.20260828.0-alpha",
+        "miniflare": "5.20260903.0-alpha",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260828.1",
-        "wrangler": "4.127.1",
+        "workerd": "1.20260903.1",
+        "wrangler": "4.129.0",
         "ws": "8.21.0"
       },
       "bin": {
@@ -368,13 +368,13 @@
       },
       "peerDependencies": {
         "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
-        "wrangler": "^4.127.1"
+        "wrangler": "^4.129.0"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260828.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260828.1.tgz",
-      "integrity": "sha512-CVd+xPhqUESg8Xhq09TZx0wl4FSirfJGOzvbPz2yHhBIvmNHFFQkSN3rkd7wEwnhQQk37Xi0/aD6ykPLJbmGiQ==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260903.1.tgz",
+      "integrity": "sha512-FG+4mGxAXhKiL/1temH42alevIkumtYXNidhTa//3yULpzux6APw5UNVocI/vCQ1yG1YOEZRfbVy8lyuipM9MQ==",
       "cpu": [
         "x64"
       ],
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260828.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260828.1.tgz",
-      "integrity": "sha512-5HDPXRM152vU5JveByGFk34X57TVyIsfp4cabepAf45DC0MKvm52ucJqAjW1h8bvW4X+zRw9GU35OHF9FEC9Ww==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-o241VefnjG8eG+kGap5CjgV4zOT5UaAmS3OR1VZCpNj7vkXGxvp9KftKvtQgcCsIqJKaKx+7Xd7xq0L1DjkfPQ==",
       "cpu": [
         "arm64"
       ],
@@ -406,9 +406,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260828.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260828.1.tgz",
-      "integrity": "sha512-MQ1Ll9P7F72HHUKizbb7BlDfbY8fRoNMpbIpZoU6uKsSkneFICWSKv6UlgU9EQZ+w0i7TMa12iUgJ8l29eRI9A==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260903.1.tgz",
+      "integrity": "sha512-/VEvvtQ/XKf6HlBbg6FbvpwcpfYUcx6Fv6RkASY8DyEmUyuJ8rc7Qxil83ClRFoBzz/GY0BV94UZ6F+wers/hg==",
       "cpu": [
         "x64"
       ],
@@ -423,9 +423,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260828.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260828.1.tgz",
-      "integrity": "sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-OWhihGC6KoTXF4u2C1AonfpgXeM4/7p/1IXuALqXESmFUpLLP5gZhRzjSk/gWW+mrCZDfSrvnjifl+lRqselbA==",
       "cpu": [
         "arm64"
       ],
@@ -440,9 +440,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260828.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260828.1.tgz",
-      "integrity": "sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260903.1.tgz",
+      "integrity": "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ==",
       "cpu": [
         "x64"
       ],
@@ -2250,28 +2250,28 @@
       "license": "MIT"
     },
     "node_modules/@posthog/browser-common": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.7.1.tgz",
-      "integrity": "sha512-JO/5dIVx3NTrbg0W2VciDDmmizsvwaYYHE5cnJE1Gra+UqBnEuVGH9DTE/kBFgVMp+08z5uj/aAprsYD2WG/QQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.7.3.tgz",
+      "integrity": "sha512-663KkV0SlP4SqrhdMZG0VumuXc8Aq602il6Z/M48ZUjIPMHZW65bzGIh1Sqfzd9ryjKOxdpOOQy9vCCL0zhXXQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/core": "^1.50.0",
-        "@posthog/types": "^1.407.1"
+        "@posthog/core": "^1.50.6",
+        "@posthog/types": "^1.409.1"
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.50.2",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.50.2.tgz",
-      "integrity": "sha512-El7y/ipZ45OFBRTN/+ixat9Nw21bW+pKKnX0G+rG4rWxBtDA47Ub/ZUnHvZNhAufNInQr4AYCUeWQsuJsTcoKg==",
+      "version": "1.50.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.50.6.tgz",
+      "integrity": "sha512-Lno7WoIk5QI/HvlkW+ajfrE/DKTrKoA5pULB/HK6Om/ShGGUAJfOpOn22yWBtBvZ6R+bhAEsWXtzcc8QwNF8gQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "^1.407.1"
+        "@posthog/types": "^1.409.1"
       }
     },
     "node_modules/@posthog/react": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@posthog/react/-/react-1.10.5.tgz",
-      "integrity": "sha512-lehh9+mJwb6iEjRBkIvh8olnJ6RV+YgQgdgJ6fdTr+T7EMoml/G1k+q92Oil8vZPcA9Dzg+2n0xaLY5yZrY3YA==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@posthog/react/-/react-1.10.6.tgz",
+      "integrity": "sha512-eXCxqrXT53MLU+xaiE1SeoIU7kMagQnWOhh/075cfckjfl4/K0yBpeQw8rn2yGFyDxEnXN+rxV/YGEELpnW3GA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">=16.8.0",
@@ -2285,9 +2285,9 @@
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.407.2",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.407.2.tgz",
-      "integrity": "sha512-F/x/qlZSGiianCEZlZ9XRYHUYffH07Zv+1oOllxAw15ifObagxSZzc2IneZE01eFqPl2OmoNuY86ER5Uyvy8Zw==",
+      "version": "1.409.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.409.1.tgz",
+      "integrity": "sha512-lA2sSGQUdVknSQl93uN9eUXDwkCMjAuthq24GONGHzMWwVygsKNHlWCnlJsVv2giDokj2p1NopO4zsE2S7gYjA==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
@@ -3000,9 +3000,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3020,9 +3020,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3868,9 +3868,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
-      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.5.tgz",
+      "integrity": "sha512-uiRYvQYe/nNSzBJ7OUnd2/TZVsAdob3blml44teEpee9Cc1f4rGZFewO+JT3Wo8mgFOSzNqes4FHZn/Qz8WOuw==",
       "dev": true,
       "funding": [
         {
@@ -3888,8 +3888,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.6",
-        "caniuse-lite": "^1.0.30001806",
+        "browserslist": "^4.28.9",
+        "caniuse-lite": "^1.0.30001810",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -4015,9 +4015,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -4035,11 +4035,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5176,9 +5176,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.417",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.417.tgz",
-      "integrity": "sha512-4T+DTDWuMPM4aHlHwWdAVCVWwp7LDilnhzkj+c/Lbj91XSQrLuOmZSLtS9Q4iIqjlPUbPOnC624zDVVHCHaolQ==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7613,16 +7613,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260828.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260828.0-alpha.tgz",
-      "integrity": "sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==",
+      "version": "5.20260903.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260903.0-alpha.tgz",
+      "integrity": "sha512-VCZIFxOqFXeibRBJWwTlppqbv2lkeO10IX3QBRGK9j1QiMAfH/OSsCvbjp1MslBMhVZmy2VTRlVaVnsKnbDp6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260828.1",
+        "workerd": "1.20260903.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -8286,14 +8286,14 @@
       "license": "MIT"
     },
     "node_modules/posthog-js": {
-      "version": "1.424.1",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.424.1.tgz",
-      "integrity": "sha512-5jJ3PWPDbJ255gcIgANRGt83npqb6hNwgmDt67PmaNMW3ZRTo+arlooEJaSC+poAAJHgsAU4VL0NJ9i/rvmd5g==",
+      "version": "1.427.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.427.3.tgz",
+      "integrity": "sha512-uI6ogY9pX1edlkCfX8KuomXjRx957hRHtzcRHp7eeMS35f8o+cLgEzATXtAogLUxQAe6f0Ud2zkljGHVrosQwg==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@posthog/browser-common": "^0.7.1",
-        "@posthog/core": "^1.50.2",
-        "@posthog/types": "^1.407.1",
+        "@posthog/browser-common": "^0.7.3",
+        "@posthog/core": "^1.50.6",
+        "@posthog/types": "^1.409.1",
         "core-js": "^3.49.0",
         "dompurify": "^3.4.13",
         "fflate": "^0.4.8",
@@ -10005,9 +10005,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260828.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260828.1.tgz",
-      "integrity": "sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==",
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260903.1.tgz",
+      "integrity": "sha512-xJzt2RnCy7ulOULmZy/4JLbEPg1uisp9lVoOUsEz+UVhDsTmrSQ0rBXZMGcXuhr2HCGKs89bg8nnbbzvBSX1Ig==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -10018,17 +10018,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260828.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260828.1",
-        "@cloudflare/workerd-linux-64": "1.20260828.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260828.1",
-        "@cloudflare/workerd-windows-64": "1.20260828.1"
+        "@cloudflare/workerd-darwin-64": "1.20260903.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260903.1",
+        "@cloudflare/workerd-linux-64": "1.20260903.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260903.1",
+        "@cloudflare/workerd-windows-64": "1.20260903.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.127.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.1.tgz",
-      "integrity": "sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==",
+      "version": "4.129.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.129.0.tgz",
+      "integrity": "sha512-PGPvs9UPoFrwxT0VogpESSZGvZIctAuTK3wGsLLPHtHsSgS85kNdvtpa2d14UzG8gwLWD64XUGFPGG9tOXG9VQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -10036,10 +10036,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260828.0-alpha",
+        "miniflare": "5.20260903.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260828.1"
+        "workerd": "1.20260903.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -10053,7 +10053,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260828.1"
+        "@cloudflare/workers-types": "^5.20260903.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -15,30 +15,30 @@
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",
-    "@posthog/react": "^1.10.5",
+    "@posthog/react": "^1.10.6",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "isbot": "^5.2.2",
-    "posthog-js": "^1.424.1",
-    "react": "^19.2.7",
+    "posthog-js": "^1.427.3",
+    "react": "^19.2.8",
     "react-day-picker": "^8.10.2",
-    "react-dom": "^19.2.7",
+    "react-dom": "^19.2.8",
     "react-router": "8.3.1",
     "tailwind-merge": "^2.6.1",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "^1.54.2",
+    "@cloudflare/vite-plugin": "^1.54.4",
     "@react-router/dev": "8.3.1",
-    "@types/node": "^26.4.0",
-    "@types/react": "^19.2.7",
-    "@types/react-dom": "^19.2.3",
+    "@types/node": "^26.4.1",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.7",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
-    "autoprefixer": "^10.5.4",
+    "autoprefixer": "^10.5.5",
     "dotenv": "^16.6.1",
     "drizzle-kit": "^0.31.10",
     "eslint": "^8.38.0",
@@ -53,7 +53,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.2.2",
     "vite-tsconfig-paths": "^5.1.4",
-    "wrangler": "^4.127.1"
+    "wrangler": "^4.129.0"
   },
   "engines": {
     "node": ">=22.22.0"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "wayf",
   "main": "./workers/app.ts",
-  "compatibility_date": "2026-08-31",
+  "compatibility_date": "2026-09-07",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": true,
   "routes": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Weekly dependency maintenance only. No product, schema, or styling changes. Open docs PR #20 is untouched.

## What moved
- `wrangler` `^4.127.1` → `^4.129.0`
- `@cloudflare/vite-plugin` `^1.54.2` → `^1.54.4` (peer wants wrangler `^4.129.0`)
- `react` / `react-dom` `^19.2.7` → `^19.2.8`
- `@types/react` `^19.2.7` → `^19.2.18` (aligned with React 19.2)
- `@types/react-dom` `^19.2.3` → `^19.2.7`
- `posthog-js` `^1.424.1` → `^1.427.3`
- `@posthog/react` `^1.10.5` → `^1.10.6`
- `@types/node` `^26.4.0` → `^26.4.1`
- `autoprefixer` `^10.5.4` → `^10.5.5`
- `wrangler.jsonc` `compatibility_date` `2026-08-31` → `2026-09-07`

## What stayed
- `react-router` / `@react-router/dev` pinned at `8.3.1`
- `vite` `^8.2.2`
- `@neondatabase/serverless` `^1.1.0`, `drizzle-orm` `^0.45.2`, `drizzle-kit` `^0.31.10`, `isbot` `^5.2.2`
- `react-day-picker` `8.10.2` (no v9/v10 jump)
- ESLint 8, Tailwind 3, TypeScript 5, `vite-tsconfig-paths` 5 (no rewrite-sized majors)
- Custom domains `wayf.quietlymadesoftware.com` and `wayf.grainlabs.co`
- `DATABASE_URL` remains a Worker secret (not in `vars`)
- `workers_dev: true`, `nodejs_compat`, `assets.run_worker_first` for `/` and `/create`
- Vercel stays redirect-only; `/m/:id` URLs and Neon schema unchanged

## Verification
- `npm install` succeeded
- `npm run build` passed
- `npm run typecheck` passed (`wrangler types` + `react-router typegen` + `tsc --noEmit`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0802bc6d-727b-407b-b71d-f0977f99894b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0802bc6d-727b-407b-b71d-f0977f99894b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

